### PR TITLE
Add wandb logging & progress bars

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ scikit-learn
 pyyaml
 tqdm
 peft>=0.10.0
+wandb
 


### PR DESCRIPTION
## Summary
- log training and validation metrics to wandb when enabled
- add progress bars for training and evaluation
- include wandb in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683d91bb3ae8832eb0551f9963b34119