### PR TITLE
Update TimeLLM patch embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ LLM4EHR/
 ├── requirements.txt           # 依赖 (torch, transformers, accelerate …)
 │
 ├── config/                    # 每个 YAML = 一组实验超参
-│   ├── ihm_llama3_8b.yaml     # 48 h IHM 二分类
-│   ├── pheno_llama3_8b.yaml   # 24 h Pheno 多标签
-│   └── pheno_clinical_longformer.yaml
+│   ├── ihm_llama3_8b.yaml        # 48 h IHM 二分类
+│   ├── pheno_llama3_8b.yaml      # 24 h Pheno 多标签
+│   ├── pheno_clinical_longformer.yaml
+│   └── pheno_timellm.yaml        # TimeLLM 时序+文本
 │
 ├── sampledata/                # 测试数据（前30个数据点）
 │   ├── ihm/                   # 48h mortality prediction samples
@@ -36,7 +37,9 @@ LLM4EHR/
 │   │   └── collate.py         # tokenize→pad
 │   │
 │   ├── models/
-│   │   └── llama_mean.py      # Llama-3 8B + masked-mean pooling + 线性头 (+LoRA/4-bit)
+│   │   ├── llama_mean.py         # Llama-3 8B baseline
+│   │   ├── timellm.py            # TimeLLM 模型实现
+│   │   └── clinicallongformer.py # Clinical-Longformer baseline
 │   │
 │   ├── metrics.py             # AUPRC / AUROC / F1 / ACC 计算
 │   ├── train.py               # Accelerate 驱动的纯-PyTorch 训练循环

--- a/config/pheno_timellm.yaml
+++ b/config/pheno_timellm.yaml
@@ -4,14 +4,14 @@ test_pkl: ${DATA_ROOT}/pheno/test_p2x_data.pkl
 
 save_path: models/pheno_timellm
 
-max_seq_len: 6000
+max_seq_len: 500
 batch_size: 4
 num_epochs: 3
 lr: 1e-5
 weight_decay: 0.01
 warmup_ratio: 0.1
 grad_accum: 2
-pretrained_meta_model: meta-llama/Meta-Llama-3-8B-Instruct #hf-internal-testing/tiny-random-gpt2
+pretrained_meta_model: hf-internal-testing/tiny-random-gpt2 # meta-llama/Meta-Llama-3-8B-Instruct
 use_4bit: false
 lora:
   r: 16


### PR DESCRIPTION
## Summary
- implement lazy 2-layer MLP `TokenEmbedding`
- change `PatchEmbedding` to combine all variables per patch
- update README project structure for TimeLLM configuration and models
- set TimeLLM config to use `tiny-random-gpt2` and limit sequence length for testing

## Testing
- `DATA_ROOT=sampledata python -m src.test --config config/pheno_timellm.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6847ad87cee0832eb94aa0e4fd19c184