### PR TITLE
Add classifier head options to GPT4MTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-models/
+/models/
 wandb/
 __pycache__/
 src/**/__pycache__/

--- a/config/ihm_gpt4mts.yaml
+++ b/config/ihm_gpt4mts.yaml
@@ -1,0 +1,32 @@
+train_pkl: ${DATA_ROOT}/ihm/train_p2x_data.pkl
+val_pkl: ${DATA_ROOT}/ihm/val_p2x_data.pkl
+test_pkl: ${DATA_ROOT}/ihm/test_p2x_data.pkl
+
+save_path: models/ihm_gpt4mts
+
+max_seq_len: 128
+batch_size: 2
+num_epochs: 3
+lr: 2e-5
+weight_decay: 0.01
+warmup_ratio: 0.1
+grad_accum: 1
+pretrained_meta_model: hf-internal-testing/tiny-random-gpt2
+use_4bit: false
+lora: null
+
+seq_len: 48
+patch_size: 8
+stride: 4
+gpt_layers: 6
+d_model: 32
+freeze: false
+pretrain: true
+revin: false
+classifier_head: linear
+
+model_type: gpt4mts
+task: ihm
+num_labels: 1
+wandb: false
+mixed_precision: "no"

--- a/config/pheno_gpt4mts.yaml
+++ b/config/pheno_gpt4mts.yaml
@@ -1,0 +1,32 @@
+train_pkl: ${DATA_ROOT}/pheno/train_p2x_data.pkl
+val_pkl: ${DATA_ROOT}/pheno/val_p2x_data.pkl
+test_pkl: ${DATA_ROOT}/pheno/test_p2x_data.pkl
+
+save_path: models/pheno_gpt4mts
+
+max_seq_len: 128
+batch_size: 2
+num_epochs: 3
+lr: 2e-5
+weight_decay: 0.01
+warmup_ratio: 0.1
+grad_accum: 1
+pretrained_meta_model: hf-internal-testing/tiny-random-gpt2
+use_4bit: false
+lora: null
+
+seq_len: 24
+patch_size: 8
+stride: 4
+gpt_layers: 6
+d_model: 32
+freeze: false
+pretrain: true
+revin: false
+classifier_head: linear
+
+model_type: gpt4mts
+task: pheno
+num_labels: 25
+wandb: false
+mixed_precision: "no"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ pyyaml
 tqdm
 peft>=0.10.0
 wandb
+einops
 

--- a/src/data/collate.py
+++ b/src/data/collate.py
@@ -3,13 +3,44 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 import torch
-from transformers import PreTrainedTokenizer
+from transformers import PreTrainedTokenizer, PreTrainedModel
 
 
-def collate_fn(tokenizer: PreTrainedTokenizer, max_length: int, model_type: str = "llama"):
+def collate_fn(
+    tokenizer: PreTrainedTokenizer,
+    max_length: int,
+    model_type: str = "llama",
+    text_encoder: PreTrainedModel | None = None,
+):
     """Create a collate function for DataLoader."""
 
-    def _fn(batch: List[Dict[str, Any]]) -> Dict[str, torch.Tensor]:
+    def _fn(batch: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if model_type == "gpt4mts":
+            assert text_encoder is not None, "text_encoder is required for gpt4mts"
+            labels, ts, summaries = [], [], []
+            for ex in batch:
+                labels.append(ex["label"])
+                ts.append(torch.tensor(ex["reg_ts"], dtype=torch.float32))
+                notes = ex["text_list"][:5]
+                if not notes:
+                    notes = [" "]
+                enc = tokenizer(
+                    notes,
+                    padding=True,
+                    truncation=True,
+                    max_length=max_length,
+                    return_tensors="pt",
+                )
+                with torch.no_grad():
+                    out = text_encoder(**enc)
+                summaries.append(out.last_hidden_state[:, 0, :])
+            labels_tensor = torch.tensor(labels, dtype=torch.float32)
+            return {
+                "summary_emb": summaries,
+                "reg_ts": torch.stack(ts),
+                "labels": labels_tensor,
+            }
+
         docs: List[str] = []
         labels = []
         for example in batch:
@@ -46,7 +77,7 @@ def collate_fn(tokenizer: PreTrainedTokenizer, max_length: int, model_type: str 
             seq_len = global_attention_mask.size(1)
             idx = torch.arange(0, seq_len, 128, device=global_attention_mask.device)
             # 仅在有效 token 上置 1
-            valid_idx = (attention_mask[:, idx] == 1).long()    
+            valid_idx = (attention_mask[:, idx] == 1).long()
             global_attention_mask[:, idx] = valid_idx
 
             # 保底：始终给 CLS 位置全局注意力

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -41,8 +41,8 @@ class MIMICDataset(Dataset):
         else:
             label = np.array(item["label"][1:], dtype=np.float32)
         out = {"text_list": texts_sorted, "label": label}
-        if self.model_type == "timellm":
-            out["reg_ts"] = item["reg_ts"][:,:17].astype(np.float32)
+        if self.model_type in {"timellm", "gpt4mts"}:
+            out["reg_ts"] = item["reg_ts"][:, :17].astype(np.float32)
         return out
 
 

--- a/src/models/gpt4mts.py
+++ b/src/models/gpt4mts.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import torch
+from torch import nn
+from transformers import AutoModel, AutoTokenizer, GPT2Model, GPT2Config
+from einops import rearrange
+
+
+class RevIn(nn.Module):
+    """Simple reversible instance normalization used in GPT4MTS."""
+
+    def __init__(self, num_features: int, eps: float = 1e-5, affine: bool = True) -> None:
+        super().__init__()
+        self.num_features = num_features
+        self.eps = eps
+        self.affine = affine
+        if affine:
+            self.weight = nn.Parameter(torch.ones(num_features))
+            self.bias = nn.Parameter(torch.zeros(num_features))
+        else:
+            self.register_parameter("weight", None)
+            self.register_parameter("bias", None)
+
+    def forward(self, x: torch.Tensor, mode: str) -> torch.Tensor:
+        if mode == "norm":
+            self.mean = x.mean(dim=1, keepdim=True).detach()
+            self.std = torch.sqrt(x.var(dim=1, keepdim=True, unbiased=False) + self.eps).detach()
+            x = (x - self.mean) / self.std
+            if self.affine:
+                x = x * self.weight + self.bias
+            return x
+        elif mode == "denorm":
+            if self.affine:
+                x = (x - self.bias) / (self.weight + self.eps * self.eps)
+            x = x * self.std + self.mean
+            return x
+        else:
+            raise ValueError("mode must be 'norm' or 'denorm'")
+
+
+@dataclass
+class GPT4MTSOutput:
+    """Output of :class:`GPT4MTS`."""
+
+    logits: torch.Tensor
+    loss: Optional[torch.Tensor]
+
+
+class HierAggregationHead(nn.Module):
+    """Hierarchical aggregation classifier head.
+
+    Parameters
+    ----------
+    d_model: int
+        Dimension of GPT hidden states.
+    num_classes: int
+        Number of prediction classes.
+    max_channels: int, default 17
+        Maximum number of time-series channels.
+    d_mid: int, default 256
+        Hidden dimension inside the head.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        num_classes: int,
+        max_channels: int = 17,
+        d_mid: int = 256,
+    ) -> None:
+        super().__init__()
+        self.proj = nn.Linear(d_model, d_mid, bias=False)
+        self.cls_token = nn.Parameter(torch.randn(1, 1, d_mid))
+        self.patch_attn = nn.TransformerEncoderLayer(d_mid, nhead=4, batch_first=True)
+        self.var_emb = nn.Parameter(torch.randn(max_channels, d_mid))
+        self.chan_qk = nn.Linear(d_mid, 2 * d_mid, bias=False)
+        self.norm = nn.LayerNorm(d_mid)
+        self.drop = nn.Dropout(0.2)
+        self.fc = nn.Linear(d_mid, num_classes)
+        self.d_mid = d_mid
+
+    def forward(self, h: torch.Tensor) -> torch.Tensor:
+        """Aggregate patch embeddings hierarchically.
+
+        Parameters
+        ----------
+        h: Tensor of shape ``(B, C, N, d_model)``
+
+        Returns
+        -------
+        Tensor of shape ``(B, num_classes)``.
+        """
+
+        B, C, N, _ = h.shape
+        h_patch = self.proj(h)  # (B, C, N, d_mid)
+        h_patch = h_patch.view(B * C, N, self.d_mid)
+        cls = self.cls_token.expand(B * C, -1, -1)
+        h_patch = torch.cat([cls, h_patch], dim=1)
+        h_chan = self.patch_attn(h_patch)[:, 0, :]
+        h_chan = h_chan.view(B, C, self.d_mid)
+        h_chan = h_chan + self.var_emb[:C]
+        qk = self.chan_qk(h_chan)
+        q, k = qk.chunk(2, dim=-1)
+        attn = (q @ k.transpose(-2, -1)) / (self.d_mid ** 0.5)
+        attn = attn.softmax(dim=-1)
+        g = (attn @ h_chan).mean(dim=1)
+        logits = self.fc(self.drop(self.norm(g)))
+        return logits
+
+
+class GPT4MTS(nn.Module):
+    """PyTorch implementation of GPT4MTS for classification tasks.
+
+    Parameters
+    ----------
+    gpt_model: str
+        Name of the GPT2 model to load.
+    num_labels: int
+        Number of prediction labels.
+    seq_len: int
+        Length of the regularized time series.
+    patch_size: int
+        Patch length when patchifying the time series and text embeddings.
+    stride: int
+        Stride when patchifying.
+    gpt_layers: int, default 6
+        Number of GPT2 layers to keep.
+    d_model: int, default 768
+        Hidden dimension fed into GPT2.
+    freeze: bool, default False
+        If ``True``, freeze GPT2 parameters except layernorms and positional embeddings.
+    pretrain: bool, default True
+        If ``True``, load pretrained GPT2 weights, otherwise initialize from scratch.
+    revin: bool, default False
+        Apply reversible instance normalization on the input time series.
+    """
+
+    def __init__(
+        self,
+        gpt_model: str,
+        num_labels: int,
+        seq_len: int,
+        patch_size: int = 8,
+        stride: int = 4,
+        gpt_layers: int = 6,
+        d_model: int = 768,
+        freeze: bool = False,
+        pretrain: bool = True,
+        revin: bool = False,
+        classifier_head: str = "linear",
+    ) -> None:
+        super().__init__()
+        self.patch_size = patch_size
+        self.stride = stride
+        self.patch_num = (seq_len - patch_size) // stride + 1
+        self.padding_patch_layer = nn.ReplicationPad1d((0, self.stride))
+        self.patch_num += 1  # extra patch due to replication padding
+        self.d_model = d_model
+        self.revin = revin
+        self.num_labels = num_labels
+        self.classifier_head_type = classifier_head
+
+        if pretrain:
+            gpt2 = GPT2Model.from_pretrained(gpt_model)
+        else:
+            gpt2 = GPT2Model(GPT2Config())
+        gpt2.h = gpt2.h[:gpt_layers]
+        self.gpt2 = gpt2
+
+        if freeze and pretrain:
+            for name, param in self.gpt2.named_parameters():
+                if "ln" in name or "wpe" in name:
+                    param.requires_grad = True
+                else:
+                    param.requires_grad = False
+
+        self.in_layer = nn.Linear(patch_size, d_model)
+        self.prompt_layer = nn.Linear(d_model, d_model)
+        self.relu = nn.ReLU()
+
+        # text encoder
+        self.text_encoder = AutoModel.from_pretrained("hf-internal-testing/tiny-random-bert")
+        self.tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-bert")
+
+        if self.classifier_head_type == "linear":
+            self.classifier_head = nn.LazyLinear(num_labels)
+        elif self.classifier_head_type == "hier":
+            self.classifier_head = HierAggregationHead(d_model, num_labels)
+        else:
+            raise ValueError("unknown classifier_head")
+        self.rev_in = RevIn(num_features=1)
+
+    def get_patch(self, x: torch.Tensor) -> torch.Tensor:
+        """Patchify time series into overlapping segments.
+
+        Parameters
+        ----------
+        x: Tensor of shape ``(B, L, C)``
+
+        Returns
+        -------
+        Tensor of shape ``(B*C, N, patch_size)`` where ``N`` is number of patches.
+        """
+        x = rearrange(x, 'b l m -> b m l')
+        x = self.padding_patch_layer(x)
+        x = x.unfold(dimension=-1, size=self.patch_size, step=self.stride)
+        x = rearrange(x, 'b m n p -> (b m) n p')
+        return x
+
+    def patch_summary(self, embeds: List[torch.Tensor]) -> torch.Tensor:
+        """Patchify text-note embeddings following GPT4MTS."""
+        device = embeds[0].device
+        padded = nn.utils.rnn.pad_sequence(embeds, batch_first=True)
+        if padded.size(1) < self.patch_size:
+            extra = self.patch_size - padded.size(1)
+            last = padded[:, -1:, :].repeat(1, extra, 1)
+            padded = torch.cat([padded, last], dim=1)
+        summary = rearrange(padded, 'b l m -> b m l')
+        summary = self.padding_patch_layer(summary)
+        summary = summary.unfold(dimension=-1, size=self.patch_size, step=self.stride)
+        summary = summary.mean(dim=-1)
+        summary = rearrange(summary, 'b m l -> b l m')
+        return summary.to(device)
+
+    def get_emb(self, x: torch.Tensor, tokens: torch.Tensor | None = None) -> torch.Tensor:
+        if tokens is None:
+            return self.gpt2(inputs_embeds=x).last_hidden_state
+        a, b, _ = x.shape
+        prompt_x = self.relu(self.prompt_layer(tokens))
+        x_all = torch.cat([prompt_x, x], dim=1)
+        out = self.gpt2(inputs_embeds=x_all).last_hidden_state
+        return out[:, -b:, :]
+
+
+    def forward(
+        self,
+        reg_ts: torch.Tensor,
+        summary_emb: List[torch.Tensor],
+        labels: Optional[torch.Tensor] = None,
+    ) -> GPT4MTSOutput:
+        """Forward pass.
+
+        Parameters
+        ----------
+        reg_ts: Tensor
+            Regularized time series of shape ``(B, L, C)``.
+        summary_emb: List[Tensor]
+            List of note embeddings for each sample, each of shape ``(n_i, d_model)``.
+        labels: Optional tensor
+            Target labels of shape ``(B,)`` or ``(B, num_labels)``.
+        """
+        B, L, C = reg_ts.size()
+        device = reg_ts.device
+        if self.revin:
+            reg_ts = self.rev_in(reg_ts, "norm")
+        else:
+            mean = reg_ts.mean(1, keepdim=True).detach()
+            std = torch.sqrt(reg_ts.var(1, keepdim=True, unbiased=False) + 1e-5).detach()
+            reg_ts = (reg_ts - mean) / std
+
+        x = self.get_patch(reg_ts)
+        x = self.in_layer(x)
+
+        summary_tokens = self.patch_summary([e.to(device) for e in summary_emb])
+        summary_tokens = summary_tokens.repeat_interleave(C, dim=0)
+
+        h = self.get_emb(x, summary_tokens)
+        h = h.reshape(B, C, self.patch_num, self.d_model)
+        if self.classifier_head_type == "linear":
+            logits = self.classifier_head(h.reshape(B, -1))
+        else:
+            logits = self.classifier_head(h)
+
+        if self.revin:
+            pass  # outputs are classification logits, no denorm needed
+        else:
+            pass
+
+        loss = None
+        if labels is not None:
+            loss_fn = nn.BCEWithLogitsLoss()
+            if logits.size(1) == 1 or labels.ndim == 1:
+                loss = loss_fn(logits.squeeze(), labels.float())
+            else:
+                loss = loss_fn(logits, labels.float())
+        return GPT4MTSOutput(logits=logits, loss=loss)

--- a/src/utils.py
+++ b/src/utils.py
@@ -73,6 +73,20 @@ class TimeLLMConfig(BaseConfig):
     freezebasemodel: bool = False
 
 
+@dataclass
+class GPT4MTSConfig(BaseConfig):
+    """Configuration for GPT4MTS models."""
+    seq_len: int = 24
+    patch_size: int = 8
+    stride: int = 4
+    gpt_layers: int = 6
+    d_model: int = 768
+    freeze: bool = False
+    pretrain: bool = True
+    revin: bool = False
+    classifier_head: str = "linear"
+
+
 def parse_config_yaml(path: str) -> BaseConfig:
     """Parse YAML config file and expand environment variables."""
     with open(path, "r", encoding="utf-8") as f:
@@ -92,6 +106,7 @@ def parse_config_yaml(path: str) -> BaseConfig:
         "llama": LlamaConfig,
         "clinicallongformer": ClinicalLongformerConfig,
         "timellm": TimeLLMConfig,
+        "gpt4mts": GPT4MTSConfig,
     }
     cfg_cls = cfg_map.get(model_type, BaseConfig)
     allowed = {f.name for f in fields(cfg_cls)}


### PR DESCRIPTION
## Summary
- support hierarchical aggregation classifier head
- move note embedding generation to the dataloader
- revise patchification logic to match original repo
- include `classifier_head` in GPT4MTS config
- update training and testing scripts for new collate API
- add einops dependency

## Testing
- `pip install -q -r requirements.txt`
- `DATA_ROOT=sampledata python -m src.train --config config/pheno_gpt4mts.yaml`
- `DATA_ROOT=sampledata python -m src.test --config config/pheno_gpt4mts.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6849c28bc9f0832eb006f38f8dd02321