### PR TITLE
Update collate_fn signature

### DIFF
--- a/src/data/collate.py
+++ b/src/data/collate.py
@@ -4,15 +4,32 @@ from typing import Any, Dict, List
 
 import torch
 from transformers import PreTrainedTokenizer
+
+from ..utils import BaseConfig
 import numpy as np
 
 
 def collate_fn(
     tokenizer: PreTrainedTokenizer,
-    max_length: int,
-    model_type: str = "llama", # llama, gpt4mts, timellm, clinicallongformer, clinicalbigbird
+    cfg: BaseConfig,
 ):
-    """Create a collate function for DataLoader."""
+    """Create a collate function for DataLoader.
+
+    Parameters
+    ----------
+    tokenizer : :class:`~transformers.PreTrainedTokenizer`
+        Tokenizer used to encode text.
+    cfg : :class:`~src.utils.BaseConfig`
+        Experiment configuration. Must contain ``max_seq_len`` and ``model_type`` fields.
+    """
+
+    max_length = cfg.max_seq_len
+    model_type = cfg.model_type.lower()
+
+    # Some smaller test tokenizers may not define a pad token. ``padding``
+    # will fail in that case, so fall back to using the EOS token.
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
 
     def _fn(batch: List[Dict[str, Any]]) -> Dict[str, Any]:
         if model_type == "gpt4mts":

--- a/src/test.py
+++ b/src/test.py
@@ -88,11 +88,7 @@ def main(config_path: str) -> None:
         test_ds,
         batch_size=cfg.batch_size,
         shuffle=False,
-        collate_fn=collate_fn(
-            tokenizer,
-            cfg.max_seq_len,
-            cfg.model_type,
-        ),
+        collate_fn=collate_fn(tokenizer, cfg),
     )
 
     model, test_loader = accelerator.prepare(model, test_loader)

--- a/src/train.py
+++ b/src/train.py
@@ -124,21 +124,13 @@ def main(config_path: str) -> None:
         train_ds,
         batch_size=cfg.batch_size,
         shuffle=True,
-        collate_fn=collate_fn(
-            tokenizer,
-            cfg.max_seq_len,
-            cfg.model_type,
-        ),
+        collate_fn=collate_fn(tokenizer, cfg),
     )
     val_loader = DataLoader(
         val_ds,
         batch_size=cfg.batch_size,
         shuffle=False,
-        collate_fn=collate_fn(
-            tokenizer,
-            cfg.max_seq_len,
-            cfg.model_type,
-        ),
+        collate_fn=collate_fn(tokenizer, cfg),
     )
 
     optimizer = AdamW(


### PR DESCRIPTION
## Summary
- have `collate_fn` accept a `BaseConfig`
- update callers to pass the config object
- handle tokenizers without a pad token

## Testing
- `python - <<'EOF'
from src.data.collate import collate_fn
from src.utils import parse_config_yaml
from transformers import AutoTokenizer
import numpy as np
cfg = parse_config_yaml('config/pheno_timellm.yaml')
tokenizer = AutoTokenizer.from_pretrained('hf-internal-testing/tiny-random-gpt2')
batch=[{'text_list':['note A','note B'],'label':np.zeros(cfg.num_labels, dtype=np.float32),'reg_ts':np.zeros((2,17),dtype=np.float32)}, {'text_list':['note C'],'label':np.ones(cfg.num_labels, dtype=np.float32),'reg_ts':np.ones((2,17),dtype=np.float32)}]
collater=collate_fn(tokenizer,cfg)
collater(batch)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684fd90033b0832ea48451a3404f0533