### PR TITLE
Add CNN baseline and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,15 @@ python -m src.test --config config/pheno_lstm.yaml
 python -m src.train --config config/ihm_lstm.yaml
 python -m src.test --config config/ihm_lstm.yaml
 ```
+
+## Running the CNN baseline
+The CNN baseline also takes only the regularised time-series as input:
+```bash
+export DATA_ROOT=sampledata
+python -m src.train --config config/cnn.yaml
+python -m src.test --config config/cnn.yaml
+
+# For the IHM task
+python -m src.train --config config/ihm_cnn.yaml
+python -m src.test --config config/ihm_cnn.yaml
+```

--- a/config/cnn.yaml
+++ b/config/cnn.yaml
@@ -1,0 +1,24 @@
+train_pkl: ${DATA_ROOT}/pheno/train_p2x_data.pkl
+val_pkl: ${DATA_ROOT}/pheno/val_p2x_data.pkl
+test_pkl: ${DATA_ROOT}/pheno/test_p2x_data.pkl
+
+save_path: models/pheno_cnn
+
+max_seq_len: 0
+batch_size: 30
+num_epochs: 30
+lr: 5e-4
+weight_decay: 0.0
+warmup_ratio: 0.0
+grad_accum: 1
+pretrained_meta_model: null
+use_4bit: false
+lora: null
+num_filters: 64
+kernel_size: 3
+dropout: 0.1
+model_type: cnn
+task: pheno
+num_labels: 25
+wandb: true
+mixed_precision: "no"

--- a/config/ihm_cnn.yaml
+++ b/config/ihm_cnn.yaml
@@ -1,0 +1,24 @@
+train_pkl: ${DATA_ROOT}/ihm/train_p2x_data.pkl
+val_pkl: ${DATA_ROOT}/ihm/val_p2x_data.pkl
+test_pkl: ${DATA_ROOT}/ihm/test_p2x_data.pkl
+
+save_path: models/ihm_cnn
+
+max_seq_len: 0
+batch_size: 8
+num_epochs: 30
+lr: 5e-4
+weight_decay: 0.0
+warmup_ratio: 0.0
+grad_accum: 1
+pretrained_meta_model: null
+use_4bit: false
+lora: null
+num_filters: 64
+kernel_size: 3
+dropout: 0.1
+model_type: cnn
+task: ihm
+num_labels: 1
+wandb: true
+mixed_precision: "no"

--- a/src/data/collate.py
+++ b/src/data/collate.py
@@ -36,8 +36,8 @@ def collate_fn(
         tokenizer.pad_token = tokenizer.eos_token
 
     def _fn(batch: List[Dict[str, Any]]) -> Dict[str, Any]:
-        if model_type == "lstm":
-            """Collate regularised time-series and labels for the LSTM model."""
+        if model_type in {"lstm", "cnn"}:
+            """Collate regularised time-series and labels for LSTM/CNN."""
             labels, ts = [], []
             for ex in batch:
                 labels.append(ex["label"])

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -57,7 +57,7 @@ class MIMICDataset(Dataset):
         out = {"text_list": texts_sorted, "label": label}
         if self.model_type in {"timellm", "gpt4mts"}:
             out["reg_ts"] = item["reg_ts"][:, :17].astype(np.float32)
-        elif self.model_type == "lstm":
+        elif self.model_type in {"lstm", "cnn"}:
             out["reg_ts"] = item["reg_ts"].astype(np.float32)
         elif self.model_type == "clinicalbigbird":
             pass  # same as text-only models

--- a/src/models/cnn.py
+++ b/src/models/cnn.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+from torch import nn
+
+
+@dataclass
+class CNNOutputs:
+    """Output container for :class:`CNNClassifier`."""
+
+    logits: torch.Tensor
+    loss: Optional[torch.Tensor]
+
+
+class CNNClassifier(nn.Module):
+    """1D CNN baseline for regularised time-series.
+
+    Parameters
+    ----------
+    input_dim: int
+        Number of features at each time step (channels).
+    num_filters: int
+        Number of convolutional filters.
+    kernel_size: int
+        Size of the temporal convolution kernel.
+    num_labels: int
+        Dimension of the prediction output.
+    dropout: float, default 0.1
+        Dropout applied before the final linear layer.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        num_filters: int,
+        kernel_size: int,
+        num_labels: int,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        padding = kernel_size // 2
+        self.conv = nn.Sequential(
+            nn.Conv1d(input_dim, num_filters, kernel_size, padding=padding),
+            nn.ReLU(),
+            nn.Conv1d(num_filters, num_filters, kernel_size, padding=padding),
+            nn.ReLU(),
+        )
+        self.pool = nn.AdaptiveAvgPool1d(1)
+        self.dropout = nn.Dropout(dropout)
+        self.fc = nn.Linear(num_filters, num_labels)
+
+        # ``tokenizer`` attribute for compatibility with existing pipeline
+        self.tokenizer = None
+
+    def forward(
+        self, reg_ts: torch.Tensor, labels: Optional[torch.Tensor] = None
+    ) -> CNNOutputs:
+        """Forward pass of the CNN classifier.
+
+        Parameters
+        ----------
+        reg_ts: Tensor
+            Regularised time series of shape ``(B, T, F)``.
+        labels: Tensor, optional
+            Target labels ``(B,)`` or ``(B, num_labels)``.
+
+        Returns
+        -------
+        :class:`CNNOutputs`
+            ``logits`` has shape ``(B, num_labels)``.
+        """
+        x = reg_ts.permute(0, 2, 1)  # (B, F, T)
+        x = self.conv(x)
+        x = self.pool(x).squeeze(-1)
+        logits = self.fc(self.dropout(x))
+
+        loss = None
+        if labels is not None:
+            loss_fn = nn.BCEWithLogitsLoss()
+            if logits.size(1) == 1 or labels.ndim == 1:
+                loss = loss_fn(logits.squeeze(), labels.float())
+            else:
+                loss = loss_fn(logits, labels.float())
+        return CNNOutputs(logits=logits, loss=loss)

--- a/src/models/lstm.py
+++ b/src/models/lstm.py
@@ -9,7 +9,15 @@ from torch import nn
 
 @dataclass
 class LSTMOutputs:
-    """Output container for :class:`LSTMClassifier`."""
+    """Output container for :class:`LSTMClassifier`.
+
+    Attributes
+    ----------
+    logits: Tensor
+        Prediction scores of shape ``(B, num_labels)``.
+    loss: Tensor | None
+        Training loss if ``labels`` are provided.
+    """
 
     logits: torch.Tensor
     loss: Optional[torch.Tensor]
@@ -30,6 +38,12 @@ class LSTMClassifier(nn.Module):
         Dimension of the prediction output.
     dropout: float, default 0.1
         Dropout applied after the LSTM layer.
+
+    Input shape
+        ``(B, T, F)`` where ``T`` is the sequence length and ``F`` the number
+        of features.
+    Output shape
+        ``(B, num_labels)`` after the final linear layer.
     """
 
     def __init__(

--- a/src/test.py
+++ b/src/test.py
@@ -16,6 +16,7 @@ from .models.timellm import TimeLLM
 from .models.gpt4mts import GPT4MTS
 from .models.belt import BeltForLongTexts
 from .models.lstm import LSTMClassifier
+from .models.cnn import CNNClassifier
 from .metrics import binary_metrics, multilabel_metrics
 from .utils import parse_config_yaml, set_seed, to_device
 
@@ -81,6 +82,14 @@ def main(config_path: str) -> None:
             input_dim=34,
             hidden_dim=cfg.hidden_dim,
             num_layers=cfg.num_layers,
+            num_labels=cfg.num_labels,
+            dropout=cfg.dropout,
+        )
+    elif cfg.model_type == "cnn":
+        model = CNNClassifier(
+            input_dim=34,
+            num_filters=cfg.num_filters,
+            kernel_size=cfg.kernel_size,
             num_labels=cfg.num_labels,
             dropout=cfg.dropout,
         )

--- a/src/train.py
+++ b/src/train.py
@@ -23,6 +23,7 @@ from .models.timellm import TimeLLM
 from .models.gpt4mts import GPT4MTS
 from .models.belt import BeltForLongTexts
 from .models.lstm import LSTMClassifier
+from .models.cnn import CNNClassifier
 from .metrics import binary_metrics, multilabel_metrics
 from .utils import BaseConfig, parse_config_yaml, save_checkpoint, set_seed, to_device
 
@@ -122,6 +123,14 @@ def main(config_path: str) -> None:
             input_dim=34,
             hidden_dim=cfg.hidden_dim,
             num_layers=cfg.num_layers,
+            num_labels=cfg.num_labels,
+            dropout=cfg.dropout,
+        )
+    elif cfg.model_type == "cnn":
+        model = CNNClassifier(
+            input_dim=34,
+            num_filters=cfg.num_filters,
+            kernel_size=cfg.kernel_size,
             num_labels=cfg.num_labels,
             dropout=cfg.dropout,
         )

--- a/src/utils.py
+++ b/src/utils.py
@@ -97,6 +97,15 @@ class LSTMConfig(BaseConfig):
     num_layers: int = 1
     dropout: float = 0.1
 
+
+@dataclass
+class CNNConfig(BaseConfig):
+    """Configuration for the CNN baseline."""
+
+    num_filters: int = 64
+    kernel_size: int = 3
+    dropout: float = 0.1
+
 @dataclass
 class TimeLLMConfig(BaseConfig):
     """Configuration for TimeLLM models."""
@@ -147,6 +156,7 @@ def parse_config_yaml(path: str) -> BaseConfig:
         "gpt4mts": GPT4MTSConfig,
         "belt": BeltConfig,
         "lstm": LSTMConfig,
+        "cnn": CNNConfig,
     }
     cfg_cls = cfg_map.get(model_type, BaseConfig)
     allowed = {f.name for f in fields(cfg_cls)}


### PR DESCRIPTION
## Summary
- implement a simple 1D CNN baseline for regularised time-series
- extend loader and collate pipeline to support cnn
- add CNN configuration dataclass and YAML configs
- insert cnn branches in train/test
- document running the CNN baseline
- improve documentation for lstm model

## Testing
- `python -m src.train --config config/cnn.yaml` *(runs on sample data)*
- `python -m src.test --config config/cnn.yaml`

------
https://chatgpt.com/codex/tasks/task_e_685935b5ff54832eb659f48c6f5440d0