### PR TITLE
Add freeze option for Llama models

### DIFF
--- a/config/ihm_llama3_8b.yaml
+++ b/config/ihm_llama3_8b.yaml
@@ -17,43 +17,43 @@ lora:
   r: 8
   lora_alpha: 32
   lora_dropout: 0.05
+freeze: false
 model_type: llama
 task: ihm
 num_labels: 1
 wandb: true
 mixed_precision: "fp16"  # 可选: "no", "fp16", "bf16"
 
-"""
-关于Qlora与混合精度
-╔══════════════════╗
-║  计算时          ║   绝大多数算子 → 16-bit (FP16 或 BF16)
-║                  ║   关键累积 / loss → 32-bit (FP32)
-╚══════════════════╝
-         ▲
-         │ bitsandbytes 内核
-         ▼
-╔══════════════════╗
-║  存储时          ║   冻结的基座权重 → 4-bit 量化
-╚══════════════════╝
-
-**混合精度 (AMP)**
-
-含义：在一次前向 / 反向里 同时使用 16-bit (FP16 或 BF16) 和 32-bit (FP32) 浮点数。
-
-混合对象
-  1. 计算张量
-    FP16 / BF16 → 大部分矩阵乘、Softmax、激活、LoRA adapter 权重
-    FP32 → loss 计算、梯度累积、部分归一化统计
-  2. 自动管理: autocast 负责张量降精度; GradScaler 负责缩 / 反缩梯度，防下溢。
-
-**QLoRA 的额外"存-算混用"**
-
-加载时: load_in_4bit=True → Base LLM 权重以 int4 存储，显存压缩 ≈ ×4–6。
-计算时: bitsandbytes kernel 即时把 int4 → 16-bit (FP16 / BF16)，算完即丢。
-
-\| 层级 | 精度 | 作用 | 备注 |
-\|------|------|------|------|
-\| **存储** | int4 | 冻结 Base 权重 | 仅占显存，不训练 |
-\| **计算主力** | FP16 / BF16 | 激活、LoRA adapter、解量化临时权重 | `autocast` 控制 |
-\| **关键累积** | FP32 | loss 与梯度缓冲 | `GradScaler` 控制 |
-"""
+# 以下是关于混合精度和 QLoRA 的笔记，仅供参考
+# 关于Qlora与混合精度
+# ╔══════════════════╗
+# ║  计算时          ║   绝大多数算子 → 16-bit (FP16 或 BF16)
+# ║                  ║   关键累积 / loss → 32-bit (FP32)
+# ╚══════════════════╝
+#          ▲
+#          │ bitsandbytes 内核
+#          ▼
+# ╔══════════════════╗
+# ║  存储时          ║   冻结的基座权重 → 4-bit 量化
+# ╚══════════════════╝
+#
+# **混合精度 (AMP)**
+#
+# 含义：在一次前向 / 反向里 同时使用 16-bit (FP16 或 BF16) 和 32-bit (FP32) 浮点数。
+#
+# 混合对象
+#   1. 计算张量
+#     FP16 / BF16 → 大部分矩阵乘、Softmax、激活、LoRA adapter 权重
+#     FP32 → loss 计算、梯度累积、部分归一化统计
+#   2. 自动管理: autocast 负责张量降精度; GradScaler 负责缩 / 反缩梯度，防下溢。
+#
+# **QLoRA 的额外"存-算混用"**
+#
+# 加载时: load_in_4bit=True → Base LLM 权重以 int4 存储，显存压缩 ≈ ×4–6。
+# 计算时: bitsandbytes kernel 即时把 int4 → 16-bit (FP16 / BF16)，算完即丢。
+#
+# \| 层级 | 精度 | 作用 | 备注 |
+# \|------|------|------|------|
+# \| **存储** | int4 | 冻结 Base 权重 | 仅占显存，不训练 |
+# \| **计算主力** | FP16 / BF16 | 激活、LoRA adapter、解量化临时权重 | `autocast` 控制 |
+# \| **关键累积** | FP32 | loss 与梯度缓冲 | `GradScaler` 控制 |

--- a/config/pheno_llama3_8b.yaml
+++ b/config/pheno_llama3_8b.yaml
@@ -17,6 +17,7 @@ lora:
   r: 16
   lora_alpha: 32
   lora_dropout: 0.05
+freeze: false
 model_type: llama
 task: pheno
 num_labels: 25

--- a/src/test.py
+++ b/src/test.py
@@ -32,6 +32,7 @@ def main(config_path: str) -> None:
             cfg.num_labels,
             use_4bit=cfg.use_4bit,
             lora_cfg=cfg.lora,
+            freeze=cfg.freeze,
         )
     elif cfg.model_type == "clinicallongformer":
         model = ClinicalLongformerPool(

--- a/src/train.py
+++ b/src/train.py
@@ -73,6 +73,7 @@ def main(config_path: str) -> None:
             cfg.num_labels,
             use_4bit=cfg.use_4bit,
             lora_cfg=cfg.lora,
+            freeze=cfg.freeze,
         )
     elif cfg.model_type == "clinicallongformer":
         model = ClinicalLongformerPool(

--- a/src/utils.py
+++ b/src/utils.py
@@ -65,6 +65,7 @@ class BaseConfig:
 class LlamaConfig(BaseConfig):
     """Configuration for Llama models."""
 
+    freeze: bool = False
 
 @dataclass
 class ClinicalLongformerConfig(BaseConfig):


### PR DESCRIPTION
## Summary
- allow freezing Llama backbone via new `freeze` flag in YAML configs
- implement freezing in `LlamaMeanPool`
- propagate parameter through training and testing scripts
- update phenotype and IHM configuration files with the new option

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import yaml; print(yaml.safe_load(open('config/pheno_llama3_8b.yaml'))['freeze'])
PY`
- `python - <<'PY'
import yaml; print(yaml.safe_load(open('config/ihm_llama3_8b.yaml'))['freeze'])
PY`
- `python - <<'PY'
from src.models.llama_mean import LlamaMeanPool
m=LlamaMeanPool('HuggingFaceM4/tiny-random-LlamaForCausalLM',2,freeze=True)
print('trainable',sum(p.requires_grad for p in m.parameters()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_685a6f9ba2a8832e9df7098a1caaa874